### PR TITLE
[WIP]Ltkum correct tileJSON generation

### DIFF
--- a/mb-util
+++ b/mb-util
@@ -70,6 +70,11 @@ if __name__ == '__main__':
         help='''Dictate whether the operations should run silently''',
         action="store_true",
         default=False)
+    parser.add_option('--profile', dest='profile',
+        help='''The aws profile used to access the S3 bucket''',
+        type='string',
+        action='store',
+        default='default')
 
     (options, args) = parser.parse_args()
 

--- a/mb-util
+++ b/mb-util
@@ -37,6 +37,16 @@ if __name__ == '__main__':
         type='string',
         action='store')
 
+    parser.add_option('--urls', dest='urls',
+        help='The urls where the tiles will be available, separated by commas (example : url.a.b.com,url.c.d.com',
+        type='string',
+        action='store')
+
+    parser.add_option('--tilejson_only', dest='tilejson_only',
+        help='If this option is present, we will generate (and store) only the tileJSON.',
+        action='store_true',
+        default=False)
+
     parser.add_option('--s3path', dest='s3path',
         help='Path in S3 bucket',
         type='string',

--- a/mbutil/s3.py
+++ b/mbutil/s3.py
@@ -63,12 +63,8 @@ def _unzip_data(compressed):
     f = gzip.GzipFile(mode='rb', fileobj=inbuffer)
     try:
         data = f.read()
-        print 'yeah, yea'
     finally:
-        print 'yeah'
         f.close()
-
-    print 'we did it'
     return data
 
 
@@ -79,6 +75,7 @@ def save_to_s3(in_data, dest, bucket_name, compress=True, cached=True):
     content_encoding = None
     cache_control = 'max-age=1800, public'
     extra_args = {}
+    
 
     if compress and mimetype not in NO_COMPRESS:
         data = _gzip_data(in_data)
@@ -103,10 +100,13 @@ def save_to_s3(in_data, dest, bucket_name, compress=True, cached=True):
         if cached is False:
             extra_args['Expires'] = datetime(1990, 1, 1)
             extra_args['Metadata'] = {'Pragma': 'no-cache', 'Vary': '*'}
+        print(dest)
+        if not isinstance(data, type(b'')):
+          data = _unzip_data(data)
         s3.Object(bucket_name, dest).put(Body=data, **extra_args)
     except Exception as e:
         print('Error while uploading %s: %s' % (dest, e))
-
+        sys.exit(1)
 
 def get_file_mimetype(local_file):
     mimetype, _ = mimetypes.guess_type(local_file)

--- a/mbutil/s3.py
+++ b/mbutil/s3.py
@@ -88,7 +88,7 @@ def save_to_s3(in_data, dest, bucket_name, compress=True, cached=True):
         compressed = True
  
     if compressed == True:
-        content_encoding = 'gzip'
+        extra_args['ContentEncoding'] = 'gzip' if compressed is True else None
 
     if cached is False:
         cache_control = 'max-age=0, must-revalidate, s-maxage=900'
@@ -96,16 +96,13 @@ def save_to_s3(in_data, dest, bucket_name, compress=True, cached=True):
     #extra_args['ACL'] = 'public-read'
     extra_args['ContentType'] = mimetype
     extra_args['CacheControl'] = cache_control
-
+    
     try:
         logger.info('Uploading to %s - %s, gzip: %s, cache headers: %s' % (dest, mimetype, compressed, cached))
-        if compressed:
-            extra_args['ContentEncoding'] = content_encoding
 
         if cached is False:
             extra_args['Expires'] = datetime(1990, 1, 1)
             extra_args['Metadata'] = {'Pragma': 'no-cache', 'Vary': '*'}
-
         s3.Object(bucket_name, dest).put(Body=data, **extra_args)
     except Exception as e:
         print('Error while uploading %s: %s' % (dest, e))

--- a/mbutil/util.py
+++ b/mbutil/util.py
@@ -288,7 +288,8 @@ def mbtiles_to_disk(mbtiles_file, directory_path, **kwargs):
 def _mbtiles_to(mbtiles_file, directory_path, target, **kwargs):
     s3 = (target == 's3')
     if s3:
-        init_connection(kwargs.get('s3bucket'), 'ltjeg_aws_admin')
+        profile=os.environ['AWS_PROFILE_NAME'] if os.environ['AWS_PROFILE_NAME'] != '' else 'default'
+        init_connection(kwargs.get('s3bucket'), profile)
     silent = kwargs.get('silent')
     if not silent:
         logger.debug("Exporting MBTiles to " + target)

--- a/mbutil/util.py
+++ b/mbutil/util.py
@@ -301,7 +301,7 @@ def _mbtiles_to(mbtiles_file, directory_path, target, **kwargs):
         os.mkdir("%s" % directory_path)
         json.dump(metadata, open(os.path.join(directory_path, '.json'), 'w'), indent=4)
     else:
-        save_to_s3(json.dumps(metadata, indent=4), base_path + 'metadata.json', kwargs.get('s3bucket'), False)
+        save_to_s3(json.dumps(metadata, indent=4), base_path + '.json', kwargs.get('s3bucket'), False)
     count = con.execute('select count(zoom_level) from tiles;').fetchone()[0]
     done = 0
     msg = ''
@@ -350,7 +350,7 @@ def _mbtiles_to(mbtiles_file, directory_path, target, **kwargs):
             f.write(t[3])
             f.close()
         else:
-            save_to_s3(t[3], tile, kwargs.get('s3bucket'))
+            save_to_s3(t[3], tile, kwargs.get('s3bucket'), kwargs.get('compression'), True)
         done = done + 1
         for c in msg: sys.stdout.write(chr(8))
         if not silent:

--- a/mbutil/util.py
+++ b/mbutil/util.py
@@ -288,7 +288,7 @@ def mbtiles_to_disk(mbtiles_file, directory_path, **kwargs):
 def _mbtiles_to(mbtiles_file, directory_path, target, **kwargs):
     s3 = (target == 's3')
     if s3:
-        profile=os.environ['AWS_PROFILE_NAME'] if os.environ['AWS_PROFILE_NAME'] != '' else 'default'
+        profile=kwargs.get('profile')
         init_connection(kwargs.get('s3bucket'), profile)
     silent = kwargs.get('silent')
     if not silent:

--- a/mbutil/util.py
+++ b/mbutil/util.py
@@ -299,7 +299,7 @@ def _mbtiles_to(mbtiles_file, directory_path, target, **kwargs):
     base_path = directory_path
     if not s3:
         os.mkdir("%s" % directory_path)
-        json.dump(metadata, open(os.path.join(directory_path, 'metadata.json'), 'w'), indent=4)
+        json.dump(metadata, open(os.path.join(directory_path, '.json'), 'w'), indent=4)
     else:
         save_to_s3(json.dumps(metadata, indent=4), base_path + 'metadata.json', kwargs.get('s3bucket'), False)
     count = con.execute('select count(zoom_level) from tiles;').fetchone()[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3==1.4.1
 botocore==1.4.70
 shapely==1.6.0
 gatilegrid==0.1.3
+numpy==1.16.1


### PR DESCRIPTION
left to do : 
 [[]] cleanup : I'm pretty sure there are better ways to do what I did, but I was in a bit of a rush
 [[]] documentation : Because knowing what to give as input can help a lot.
 [[]] command line simplification : The command We currently use to deploy to s3 with a correct tileJSON is the following : 
.venv/bin/python mb-util [PATH TO MBTILES] s3 --s3bucket="[BUCKET]" --s3path="[PATH IN THE BUCKET]" --image_format="pbf" --scheme="xyz" --profile="[AMAZON PROFILE]" --urls="https://[HOST1]/[PATH IN THE BUCKET]/{z}/{x}/{y}.pbf,https://[HOST2]/[PATH IN THE BUCKET]/{z}/{x}/{y}.pbf,https://[HOST3]/[PATH IN THE BUCKET]/{z}/{x}/{y}.pbf,https://[HOST4]/[PATH IN THE BUCKET]/{z}/{x}/{y}.pbf --tilejson_only

a first amelioration would be to reuse "path in the bucket" and simply specifiy hostnames as variables for the tiles[] part of the tileJSON. 